### PR TITLE
Develop

### DIFF
--- a/AccountInfoDisplayer.py
+++ b/AccountInfoDisplayer.py
@@ -137,8 +137,8 @@ class AccountInfoDisplayer:
                     f"<b>💵 Entry:</b> <code>{elem['avgPrice']}</code>\n"
                     f"<b>📊 Side:</b> <code>{elem['side']}</code>\n"
                     f"<b>📏 Size:</b> <code>{elem['size']}</code>\n"
-                    f"<b>🎯 Take Profit:</b> <code>{elem['takeProfit']} ({tp_pct})</code>\n"
-                    f"<b>🛑 Stop Loss:</b> <code>{elem['stopLoss']} ({sl_pct})</code>\n"
+                    f"<b>🎯 TP:</b> <code>{elem['takeProfit']} ({tp_pct})</code>\n"
+                    f"<b>🛑 SL:</b> <code>{elem['stopLoss']} ({sl_pct})</code>\n"
                     f"<s>━━━━━━━━━━━━━━━</s>"
                 )
             telegram.send_message(positions_msg)

--- a/TelegramBot.py
+++ b/TelegramBot.py
@@ -19,7 +19,7 @@ class TelegramBot:
         except Exception as e:
             print(f"Error sending telegram message: {e}")
             
-    def send_trade_message(self, symbol: str, side: OrderSide, entry: float, tp: float, sl: float, algorithm: str):
+    def send_trade_message(self, symbol, side, entry, tp, sl, algorithm):
         emoji = "🟢" if side == OrderSide.BUY.value else "🔴"
         message = f"""{emoji} New {side.value} Position
                     Algorithm: {algorithm}

--- a/TelegramBot.py
+++ b/TelegramBot.py
@@ -21,7 +21,7 @@ class TelegramBot:
             
     def send_trade_message(self, symbol, side, entry, tp, sl, algorithm):
         emoji = "🟢" if side == OrderSide.BUY.value else "🔴"
-        message = f"""{emoji} New {side.value} Position
+        message = f"""{emoji} New {side} Position
                     Algorithm: {algorithm}
                     Symbol: {symbol}
                     Entry: {entry}


### PR DESCRIPTION
- Shortened "Take Profit" to "TP" and "Stop Loss" to "SL" in position display messages
- Removed explicit type hints from TelegramBot.send_trade_message parameters
- The OrderSide parameter was already being passed as a value, making the .value accessor redundant and potentially causing errors. This commit simplifies the message formatting by directly using the side parameter.